### PR TITLE
Also test for transmissionrpc<0.9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 ; flake8 includes both pep8 and pyflakes :]
-envlist = py27,py33,py34,flake8,doc,coverage
+envlist = py27-transmissionrpc{_lt_09,_ge_09},py33,py34,flake8,doc,coverage
 
 ;
 ; test environnements
@@ -12,8 +12,9 @@ setenv = VIRTUAL_ENV={envdir}
          LC_ALL=C
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 install_command = pip install {opts} {packages}
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
+deps = -r{toxinidir}/test-requirements.txt
+       transmissionrpc_lt_09: transmissionrpc>=0.8,<0.9
+       transmissionrpc_ge_09: transmissionrpc>=0.9
 commands = python -m coverage run --parallel-mode --source collectd_transmission tests/tests.py
 
 [testenv:flake8]


### PR DESCRIPTION
Have tox.ini modified in order to enable testing for transmissionrpc
version prior to 0.9. This is namely only 0.8 since we have never
supported anything lower than that.