### PR TITLE
Enable python 3.5 unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
 install: pip install tox
 script: tox
-sudo: false
+sudo: required
+dist: trusty

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 ; flake8 includes both pep8 and pyflakes :]
-envlist = py27-transmissionrpc{_lt_09,_ge_09},py33,py34,flake8,doc,coverage
+envlist = py27-transmissionrpc{_lt_09,_ge_09},py33,py34,py35,flake8,doc,coverage
 
 ;
 ; test environnements


### PR DESCRIPTION
Since python 3.5 has been released we can now enable tox unit tests