### PR TITLE
Simulate transmission client failures

### DIFF
--- a/collectd_transmission/__init__.py
+++ b/collectd_transmission/__init__.py
@@ -113,8 +113,14 @@ def get_stats():
     '''
     Collectd routine to actually get and dispatch the statistics
     '''
-    stats = data['client'].session_stats()
     # And let's fetch our data
+    try:
+        stats = data['client'].session_stats()
+    except transmissionrpc.error.TransmissionError:
+        shutdown()
+        initialize()
+        return  # On this run, just fail to return anything
+    # Let's get our data
     for category, catmetrics in metrics.items():
         for metric, attrs in catmetrics.items():
             vl = collectd.Values(type=attrs['type'],

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,6 +3,7 @@
 import unittest
 import mock
 import sys
+from transmissionrpc.error import TransmissionError
 
 # Monkey patching the collectd module to facilitate testing
 mock_collectd = mock.MagicMock()
@@ -56,6 +57,18 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.data['client'] = mock_Client
         collectd_transmission.get_stats()
         mock_Client.session_stats.assert_called_with()
+
+    @mock.patch('collectd_transmission.transmissionrpc.Client')
+    def test_get_stats_transmissionError_exception(self, mock_Client):
+        mock_Client.session_stats = mock.MagicMock(
+            side_effect=TransmissionError('foo'))
+        collectd_transmission.collectd = mock.MagicMock()
+        collectd_transmission.config(self.config)
+        collectd_transmission.initialize()
+        collectd_transmission.data['client'] = mock_Client
+        collectd_transmission.get_stats()
+        mock_Client.session_stats.assert_called_with()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add a unit test to simulate transmission client failure by mocking the
session_stats function to throw an exception and then handle the
simulated error
Add a unit test to mock keyError happening by the config step never
having happened.