### PR TITLE
Handle an incorrect shutdown

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -48,6 +48,10 @@ class MethodTestCase(unittest.TestCase):
     def test_shutdown(self):
         collectd_transmission.shutdown()
 
+    def test_incorrect_shutdown(self):
+        del collectd_transmission.data['client']
+        collectd_transmission.shutdown()
+
     @mock.patch('collectd_transmission.transmissionrpc.Client')
     def test_get_stats(self, mock_Client):
         collectd_transmission.collectd = mock.MagicMock()


### PR DESCRIPTION
It might be that due to exceptions, shutdown is called without data
having a client Key. Test for that and handle it in the shutdown code