### PR TITLE
Simplify get_stats tests by removing redundant code

### DIFF
--- a/collectd_transmission/__init__.py
+++ b/collectd_transmission/__init__.py
@@ -68,7 +68,6 @@ def initialize():
     TIMEOUT = int(data.get('timeout', '5'))
     c = transmissionrpc.Client(address=ADDRESS, user=USERNAME, password=PASSWORD, timeout=TIMEOUT)
     data['client'] = c
-    data['client_version'] = transmissionrpc.__version__
 
 
 def shutdown():
@@ -93,7 +92,8 @@ def field_getter(stats, key, category):
         int. The metric value or 0
     '''
     # 0.9 and onwards have statistics in a different field
-    if StrictVersion(data['client_version']) >= StrictVersion('0.9'):
+    client_version = transmissionrpc.__version__
+    if StrictVersion(client_version) >= StrictVersion('0.9'):
         if category == 'cumulative':
             return stats.cumulative_stats[key]
         elif category == 'current':

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -51,9 +51,6 @@ class MethodTestCase(unittest.TestCase):
 
     @mock.patch('collectd_transmission.transmissionrpc.Client')
     def test_get_stats(self, mock_Client):
-        collectd_transmission.collectd = mock.MagicMock()
-        collectd_transmission.config(self.config)
-        collectd_transmission.initialize()
         collectd_transmission.data['client'] = mock_Client
         collectd_transmission.get_stats()
         mock_Client.session_stats.assert_called_with()
@@ -62,9 +59,6 @@ class MethodTestCase(unittest.TestCase):
     def test_get_stats_transmissionError_exception(self, mock_Client):
         mock_Client.session_stats = mock.MagicMock(
             side_effect=TransmissionError('foo'))
-        collectd_transmission.collectd = mock.MagicMock()
-        collectd_transmission.config(self.config)
-        collectd_transmission.initialize()
         collectd_transmission.data['client'] = mock_Client
         collectd_transmission.get_stats()
         mock_Client.session_stats.assert_called_with()


### PR DESCRIPTION
We don't really need any of the mocks and configs in get_stats tests, so
remove them, simplifying greatly the tests