### PR TITLE
Handle client being None or inexistent

### DIFF
--- a/collectd_transmission/__init__.py
+++ b/collectd_transmission/__init__.py
@@ -113,6 +113,11 @@ def get_stats():
     '''
     Collectd routine to actually get and dispatch the statistics
     '''
+    # If we are not correctly initialized, initialize us once more.
+    # Something happened after the first init and we have lost state
+    if 'client' not in data or data['client'] is None:
+        shutdown()
+        initialize()
     # And let's fetch our data
     try:
         stats = data['client'].session_stats()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -69,6 +69,11 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.get_stats()
         mock_Client.session_stats.assert_called_with()
 
+    @mock.patch('collectd_transmission.transmissionrpc.Client')
+    def test_get_stats_none_client(self, mock_Client):
+        collectd_transmission.data['client'] = None
+        collectd_transmission.get_stats()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It is possible that the initialization failed and for some reason we
don't have a client in the data hash. Handle that gracefully in the
get_stats function by reinitializing if needed. Issue tests for that as
well