### PR TITLE
Fix travis builds for supported python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: python
-install: pip install tox
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27-transmissionrpc_lt_09,py27-transmissionrpc_ge_09,flake8,doc,coverage
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+install: pip install 'virtualenv<16.0.0' 'tox==2.9.1'
 script: tox
-sudo: required
-dist: trusty

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 flake8
-sphinx
+sphinx<1.7
 coverage
 mock
 coveralls


### PR DESCRIPTION
Create a travis matrix to define the various tests that are to be run,
version lock for now virtualenv, tox, sphinx to support python3.3