### PR TITLE
Remove python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,9 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27-transmissionrpc_lt_09,py27-transmissionrpc_ge_09,flake8,doc,coverage
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
-install: pip install 'virtualenv<16.0.0' 'tox==2.9.1'
+install: pip install tox
 script: tox

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 flake8
-sphinx<1.7
+sphinx
 coverage
 mock
 coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 ; flake8 includes both pep8 and pyflakes :]
-envlist = py27-transmissionrpc{_lt_09,_ge_09},py33,py34,py35,flake8,doc,coverage
+envlist = py27-transmissionrpc{_lt_09,_ge_09},py34,py35,flake8,doc,coverage
 
 ;
 ; test environnements


### PR DESCRIPTION
Python 3.3 reached EOL status on 2017-09-29, no point in supporting it
anymore, remove it