### PR TITLE
Drop support for transmissionrpc 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 matrix:
   include:
     - python: 2.7
-      env: TOXENV=py27-transmissionrpc_lt_09,py27-transmissionrpc_ge_09,flake8,doc,coverage
+      env: TOXENV=py27,flake8,doc,coverage
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/collectd_transmission/__init__.py
+++ b/collectd_transmission/__init__.py
@@ -104,12 +104,7 @@ def field_getter(stats, key, category):
         else:  # We are in "general"
             return getattr(stats, key)
     else:
-        if category == 'cumulative':
-            return stats.fields['cumulative_stats'][key]
-        elif category == 'current':
-            return stats.fields['current_stats'][key]
-        else:  # We are in "general"
-            return stats.fields[key]
+        raise RuntimeError('transmissionrpc version < 0.9 found, not supported')
 
 
 def get_stats():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-transmissionrpc>=0.8
+transmissionrpc>=0.9

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+transmissionrpc>=0.9
 flake8
 sphinx
 coverage

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -67,6 +67,15 @@ class MethodTestCase(unittest.TestCase):
         mock_Client.session_stats.assert_called_with()
 
     @mock.patch('collectd_transmission.transmissionrpc.Client')
+    def test_get_stats_wrong_transmissionrpc_version(self, mock_Client):
+        collectd_transmission.data['client'] = mock_Client
+        collectd_transmission.transmissionrpc.__version__ = '0.8'
+        try:
+            collectd_transmission.get_stats()
+        except RuntimeError:
+            return True
+
+    @mock.patch('collectd_transmission.transmissionrpc.Client')
     def test_get_stats_transmissionError_exception(self, mock_Client):
         mock_Client.session_stats = mock.MagicMock(
             side_effect=TransmissionError('foo'))

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 ; flake8 includes both pep8 and pyflakes :]
-envlist = py27-transmissionrpc{_lt_09,_ge_09},py34,py35,py36,flake8,doc,coverage
+envlist = py27,py34,py35,py36,flake8,doc,coverage
 
 ;
 ; test environnements
@@ -13,8 +13,6 @@ setenv = VIRTUAL_ENV={envdir}
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
-       transmissionrpc_lt_09: transmissionrpc>=0.8,<0.9
-       transmissionrpc_ge_09: transmissionrpc>=0.9
 commands = python -m coverage run --parallel-mode --source collectd_transmission tests/tests.py
 
 [testenv:flake8]


### PR DESCRIPTION
transmissionrpc 0.8 has been released in 2011, transmissionrpc 0.9 to
0.11 in 2013. We 've supported 0.8 version long enough, drop support for
it, force 0.9+