### PR TITLE
Switch to transmission-rpc

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r test-requirements.txt
+        pip install pylint 'transmission-rpc<3.0'
     - name: Analysing the code with pylint
       run: |
         pylint --ignore=conf.py $(git ls-files '*.py')

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,6 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        transmission-rpc-version:
+          - "1.0.7"
+          - "2.0.4"
 
     steps:
     - uses: actions/checkout@v3
@@ -24,11 +27,12 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest coverage
         if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
+        python -m pip install flake8 pytest coverage transmission-rpc==${{ matrix.transmission-rpc-version }}
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/collectd_transmission/__init__.py
+++ b/collectd_transmission/__init__.py
@@ -6,9 +6,8 @@
 ..  moduleauthor:: Alexandros Kosiaris
 '''
 
-from packaging.version import Version, parse
 import collectd  # pylint: disable=import-error
-import transmissionrpc  # pylint: disable=import-error
+import transmission_rpc  # pylint: disable=import-error
 
 
 PLUGIN_NAME = 'transmission'
@@ -68,12 +67,12 @@ def initialize():
     address = data.get('address', 'http://localhost:9091/transmission/rpc')
     timeout = int(data.get('timeout', '5'))
     try:
-        client = transmissionrpc.Client(
+        client = transmission_rpc.Client(
             address=address,
             user=username,
             password=password,
             timeout=timeout)
-    except transmissionrpc.error.TransmissionError:
+    except transmission_rpc.error.TransmissionError:
         client = None
     data['client'] = client
 
@@ -99,10 +98,6 @@ def field_getter(stats, key, category):
     Returns:
         int. The metric value or 0
     '''
-    # 0.9 and onwards have statistics in a different field
-    client_version = transmissionrpc.__version__
-    if parse(client_version) <= Version('0.9'):
-        raise RuntimeError('transmissionrpc version < 0.9 found, not supported')
     if category == 'cumulative':
         return stats.cumulative_stats[key]
     if category == 'current':
@@ -123,7 +118,7 @@ def get_stats():
     # And let's fetch our data
     try:
         stats = data['client'].session_stats()
-    except transmissionrpc.error.TransmissionError:
+    except transmission_rpc.error.TransmissionError:
         shutdown()
         initialize()
         return  # On this run, just fail to return anything

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -2,25 +2,22 @@ Compatibility
 =============
 
 As long as you can install collectd 5.x with the python plugin and
-transmissionrpc 0.11 it should work out of the box
+transmission-rpc less than 3.0 it should work out of the box.
 
-Development
-===========
-Developed initially on a Debian Wheezy system.
+transmission-rpc
+================
 
-That used to mean:
+This project started off using transmissionrpc, a project that hasn't
+apparently been updated since 2014. While a number of forks do exist,
+the most promising one, in 2023, is transmission-rpc. It forked in 2018
+apparently and is still seeing updates. It has switched to SemVer,
+allowing us to more easily test against the major releases and decide on
+how to proceed. There are a number of identified notes here:
 
-* collectd 5.1
-* transmissionrpc 0.8
-
-Since then few things have changed (we no longer support tranmissionrpc 0.8)
-and python < 3.4. Still supporting python 2.7
-
-Development now continues on a Debian Stretch system. Which means:
-
-* collectd 5.7
-* transmissionrpc 0.11
-
-There is extra testing via automated means but there only so much it can do
-
-Feel free to submit PRs for other systems support
+* Versions 3.0+ broke the Client() class signature and for now we can't
+  use them
+* Versions 0.0.x and 0.1.0 used the python 2/3 compatibility layer named
+  six. Given that we don't even want to support python 2.x anymore, we
+  'll be skipping those releases to avoid installing a redundant
+  compatibility layer in users's machines. This is further justified by the
+  fact that upstream deprecated python 2 in 1.0.0

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,21 +14,17 @@ If you have not already installed transmision, install it:
 
     apt-get install transmission-daemon
 
-The above install the daemon cause a headless box is assumed. It should
+The above installs the daemon cause a headless box is assumed. It should
 probably work with a non headless box as well and a normal transmission
 installation but this has not been tested.
 
-Install the python transmission binding via either the system packages
+Install the python transmission binding
+
+via pip
 
 .. code-block:: bash
 
-    apt-get install python-transmissionrpc
-
-or plain pip
-
-.. code-block:: bash
-
-    pip install transmissionrpc
+    pip install 'transmission-rpc<3.0'
 
 Install collectd.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 [options]
 packages = collectd_transmission
 install_requires =
-    packaging
-    transmissionrpc
+    transmission-rpc < 3.0
     importlib-metadata; python_version < "3.10"
 include_package_data = True
+python_requires = >=3.8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,1 @@
-transmissionrpc>=0.9
-flake8
 sphinx
-pylint
-pytest
-packaging

--- a/tests/test_collectd_transmission.py
+++ b/tests/test_collectd_transmission.py
@@ -6,7 +6,7 @@ Tests for collectd_transmission
 import sys
 import unittest
 from unittest import mock
-from transmissionrpc.error import TransmissionError
+from transmission_rpc.error import TransmissionError
 
 # Monkey patching the collectd module to facilitate testing
 mock_collectd = mock.MagicMock()
@@ -44,7 +44,7 @@ class MethodTestCase(unittest.TestCase):
 
         collectd_transmission.configuration(self.config)
 
-    @mock.patch('collectd_transmission.transmissionrpc.Client', spec=True)
+    @mock.patch('collectd_transmission.transmission_rpc.Client', spec=True)
     def test_initialize(self, mock_client):
         '''
         Test the initialization
@@ -59,7 +59,7 @@ class MethodTestCase(unittest.TestCase):
             timeout=5)
 
     @mock.patch(
-        'collectd_transmission.transmissionrpc.Client',
+        'collectd_transmission.transmission_rpc.Client',
         spec=True,
         side_effect=TransmissionError)
     def test_initialize_fail(self, mock_client):
@@ -82,7 +82,7 @@ class MethodTestCase(unittest.TestCase):
 
         collectd_transmission.shutdown()
 
-    @mock.patch('collectd_transmission.transmissionrpc.Client', spec=True)
+    @mock.patch('collectd_transmission.transmission_rpc.Client', spec=True)
     def test_get_stats(self, mock_client):
         '''
         Test getting stats
@@ -92,20 +92,7 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.get_stats()
         mock_client.session_stats.assert_called_with()
 
-    @mock.patch('collectd_transmission.transmissionrpc.Client', spec=True)
-    def test_get_stats_wrong_transmissionrpc_version(self, mock_client):
-        '''
-        Test getting stats with a wrong version of transmission
-        '''
-
-        collectd_transmission.data['client'] = mock_client
-        collectd_transmission.transmissionrpc.__version__ = '0.8'
-        try:
-            collectd_transmission.get_stats()
-        except RuntimeError:
-            pass
-
-    @mock.patch('collectd_transmission.transmissionrpc.Client', spec=True)
+    @mock.patch('collectd_transmission.transmission_rpc.Client', spec=True)
     def test_get_stats_exception(self, mock_client):
         '''
         Test getting stats with an exception
@@ -117,7 +104,7 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.get_stats()
         mock_client.session_stats.assert_called_with()
 
-    @mock.patch('collectd_transmission.transmissionrpc.Client', spec=True)
+    @mock.patch('collectd_transmission.transmission_rpc.Client', spec=True)
     def test_get_stats_none_client(self, _):
         '''
         Test getting stats if we don't have a client object


### PR DESCRIPTION
transmissionrpc as a python package is obviously unmaintained.
A fork that went until mid 2020, transmissionrpc-ng was tried out, but

a) it's already 3 years that it has seen 0 movement
b) it decided to use pycurl, which is a native extension, making testing difficult

There is another fork, which although not explicitly stated, contains
the original one's copyright notices. We switch to using that one. For
now we stick to versions below 3.0 as there appears to have been a
breakage in 3.0