### PR TITLE
tests: spec mocks

### DIFF
--- a/tests/test_collectd_transmission.py
+++ b/tests/test_collectd_transmission.py
@@ -47,7 +47,7 @@ class MethodTestCase(unittest.TestCase):
 
         collectd_transmission.configuration(self.config)
 
-    @mock.patch('collectd_transmission.transmissionrpc.Client')
+    @mock.patch('collectd_transmission.transmissionrpc.Client', spec=True)
     def test_initialize(self, mock_client):
         '''
         Test the initialization
@@ -63,6 +63,7 @@ class MethodTestCase(unittest.TestCase):
 
     @mock.patch(
         'collectd_transmission.transmissionrpc.Client',
+        spec=True,
         side_effect=TransmissionError)
     def test_initialize_fail(self, mock_client):
         '''
@@ -84,7 +85,7 @@ class MethodTestCase(unittest.TestCase):
 
         collectd_transmission.shutdown()
 
-    @mock.patch('collectd_transmission.transmissionrpc.Client')
+    @mock.patch('collectd_transmission.transmissionrpc.Client', spec=True)
     def test_get_stats(self, mock_client):
         '''
         Test getting stats
@@ -94,7 +95,7 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.get_stats()
         mock_client.session_stats.assert_called_with()
 
-    @mock.patch('collectd_transmission.transmissionrpc.Client')
+    @mock.patch('collectd_transmission.transmissionrpc.Client', spec=True)
     def test_get_stats_wrong_transmissionrpc_version(self, mock_client):
         '''
         Test getting stats with a wrong version of transmission
@@ -107,7 +108,7 @@ class MethodTestCase(unittest.TestCase):
         except RuntimeError:
             pass
 
-    @mock.patch('collectd_transmission.transmissionrpc.Client')
+    @mock.patch('collectd_transmission.transmissionrpc.Client', spec=True)
     def test_get_stats_exception(self, mock_client):
         '''
         Test getting stats with an exception
@@ -119,7 +120,7 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.get_stats()
         mock_client.session_stats.assert_called_with()
 
-    @mock.patch('collectd_transmission.transmissionrpc.Client')
+    @mock.patch('collectd_transmission.transmissionrpc.Client', spec=True)
     def test_get_stats_none_client(self, _):
         '''
         Test getting stats if we don't have a client object


### PR DESCRIPTION
Let's spec mocks by default. It should make our unit tests be a bit more integration like as they will be at least honoring the basics of the transmissionrpc.Client class