### PR TITLE
Bump transmission rpc version

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint 'transmission-rpc<3.0'
+        pip install pylint 'transmission-rpc>=3.0'
     - name: Analysing the code with pylint
       run: |
         pylint --ignore=conf.py $(git ls-files '*.py')

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,8 +18,15 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         transmission-rpc-version:
-          - "1.0.7"
-          - "2.0.4"
+          - "3.0.1"
+          - "3.1.0"
+          - "3.2.9"
+          - "3.3.2"
+          - "3.4.2"
+          - "4.0.0"
+          - "4.1.5"
+          - "4.2.2"
+          - "4.3.0"
 
     steps:
     - uses: actions/checkout@v3

--- a/collectd_transmission/__init__.py
+++ b/collectd_transmission/__init__.py
@@ -64,12 +64,16 @@ def initialize():
     '''
     username = data['username']
     password = data['password']
-    address = data.get('address', 'http://localhost:9091/transmission/rpc')
+    host = data.get('host', 'localhost')
+    port = data.get('port', 9091)
+    path = data.get('path', '/transmission/rpc')
     timeout = int(data.get('timeout', '5'))
     try:
         client = transmission_rpc.Client(
-            address=address,
-            user=username,
+            host=host,
+            path=path,
+            port=port,
+            username=username,
             password=password,
             timeout=timeout)
     except transmission_rpc.error.TransmissionError:

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -2,7 +2,7 @@ Compatibility
 =============
 
 As long as you can install collectd 5.x with the python plugin and
-transmission-rpc less than 3.0 it should work out of the box.
+transmission-rpc higher than 3.0 it should work out of the box.
 
 transmission-rpc
 ================
@@ -14,8 +14,8 @@ apparently and is still seeing updates. It has switched to SemVer,
 allowing us to more easily test against the major releases and decide on
 how to proceed. There are a number of identified notes here:
 
-* Versions 3.0+ broke the Client() class signature and for now we can't
-  use them
+* Versions 3.0+ broke the Client() class signature. We 've adapted, but this
+  means we can't use versions below 3.0
 * Versions 0.0.x and 0.1.0 used the python 2/3 compatibility layer named
   six. Given that we don't even want to support python 2.x anymore, we
   'll be skipping those releases to avoid installing a redundant

--- a/doc/configure.rst
+++ b/doc/configure.rst
@@ -11,12 +11,17 @@ Insert the following in your collectd.conf::
         <Module collectd_transmission>
             username "myuser" # Required
             password "mypass" # Required
-            address "http://localhost:9091/transmission/rpc" # Optional, defaults to "http://localhost:9091/transmission/rpc"
-            timeout "5" # Optional, defaults to 5
+            host "localhost" # Optional
+            port "9091" # Optional
+            path "/transmission/rpc" # Optional
+            timeout "5" # Optional
         </Module>
     </Plugin>
 
-modified accordingly to your needs. Restart collectd and you are done.
+modified accordingly to your needs. Everything marked as optional, can be
+skipped. The default value is given for your convenience
+
+Restart collectd and you are done.
 
 .. code-block:: bash
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -24,7 +24,7 @@ via pip
 
 .. code-block:: bash
 
-    pip install 'transmission-rpc<3.0'
+    pip install 'transmission-rpc>3.0'
 
 Install collectd.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 [options]
 packages = collectd_transmission
 install_requires =
-    transmission-rpc < 3.0
+    transmission-rpc >= 3.0
     importlib-metadata; python_version < "3.10"
 include_package_data = True
 python_requires = >=3.9

--- a/tests/test_collectd_transmission.py
+++ b/tests/test_collectd_transmission.py
@@ -44,7 +44,9 @@ class MethodTestCase(unittest.TestCase):
 
         collectd_transmission.configuration(self.config)
 
-    @mock.patch('collectd_transmission.transmission_rpc.Client', spec=True)
+    @mock.patch(
+        'collectd_transmission.transmission_rpc.Client',
+        spec=True)
     def test_initialize(self, mock_client):
         '''
         Test the initialization
@@ -53,8 +55,10 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.configuration(self.config)
         collectd_transmission.initialize()
         mock_client.assert_called_with(
-            address='http://localhost:9091/transmission/rpc',
-            user='myusername',
+            host='localhost',
+            path='/transmission/rpc',
+            port=9091,
+            username='myusername',
             password='mypassword',
             timeout=5)
 
@@ -70,8 +74,10 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.configuration(self.config)
         collectd_transmission.initialize()
         mock_client.assert_called_with(
-            address='http://localhost:9091/transmission/rpc',
-            user='myusername',
+            host='localhost',
+            path='/transmission/rpc',
+            port=9091,
+            username='myusername',
             password='mypassword',
             timeout=5)
 


### PR DESCRIPTION
Bump transmission-rpc to > 3.0
    
transmission-rpc broke compatibility in Client() class's signature. We
adapt our own code to honor that one and switch to testing against
versions only past 3.0
