### PR TITLE
Fix metric breakage added in transmission-rpc 4.0.0

### DIFF
--- a/collectd_transmission/__init__.py
+++ b/collectd_transmission/__init__.py
@@ -7,40 +7,75 @@
 '''
 
 import collectd  # pylint: disable=import-error
-import transmission_rpc  # pylint: disable=import-error
-
+from transmission_rpc import Client, Session  # pylint: disable=import-error
+from transmission_rpc.error import TransmissionError  # pylint: disable=import-error
+try:
+    # This will only succeed past version 4.0.0
+    # The name key in the following dicts exists to avoid metric names breaking
+    # when upgrading from transmission-rpc < 4.0.0
+    from transmission_rpc.session import SessionStats
+    metrics= {
+        # General metrics
+        'general': {
+            'active_torrent_count': {'type': 'gauge', 'name': 'activeTorrentCount'},
+            'torrent_count': {'type': 'gauge', 'name': 'torrentCount'},
+            'download_speed': {'type': 'gauge', 'name': 'downloadSpeed'},
+            'upload_speed': {'type': 'gauge', 'name': 'uploadSpeed'},
+            'paused_torrent_count': {'type': 'gauge', 'name': 'pausedTorrentCount'},
+            # The following used to exist, but it is not a property of a
+            # Session instance anymore
+            # 'blocklist_size': {'type': 'gauge', 'name': 'blocklist_size'},
+        },
+        # All time metrics
+        'cumulative': {
+            'downloaded_bytes': {'type': 'counter', 'name': 'downloadedBytes'},
+            'files_added': {'type': 'counter', 'name': 'filesAdded'},
+            'uploaded_bytes': {'type': 'counter', 'name': 'uploadedBytes'},
+            'seconds_active': {'type': 'gauge', 'name': 'secondsActive'},
+            'session_count': {'type': 'gauge', 'name': 'sessionCount'},
+        },
+        # Per session (restart) metrics
+        'current': {
+            'downloaded_bytes': {'type': 'counter', 'name': 'downloadedBytes'},
+            'files_added': {'type': 'counter', 'name': 'filesAdded'},
+            'uploaded_bytes': {'type': 'counter', 'name': 'uploadedBytes'},
+            'seconds_active': {'type': 'gauge', 'name': 'secondsActive'},
+            'session_count': {'type': 'gauge', 'name': 'sessionCount'},
+        }
+    }
+except ImportError:
+    # SessionStats import failed, assume we are ransmission-rpc < 4.0.0
+    metrics= {
+        # General metrics
+        'general': {
+            'activeTorrentCount': {'type': 'gauge'},
+            'torrentCount': {'type': 'gauge'},
+            'downloadSpeed': {'type': 'gauge'},
+            'uploadSpeed': {'type': 'gauge'},
+            'pausedTorrentCount': {'type': 'gauge'},
+            'blocklist_size': {'type': 'gauge'},
+        },
+        # All time metrics
+        'cumulative': {
+            'downloadedBytes': {'type': 'counter'},
+            'filesAdded': {'type': 'counter'},
+            'uploadedBytes': {'type': 'counter'},
+            'secondsActive': {'type': 'gauge'},
+            'sessionCount': {'type': 'gauge'},
+        },
+        # Per session (restart) metrics
+        'current': {
+            'downloadedBytes': {'type': 'counter'},
+            'filesAdded': {'type': 'counter'},
+            'uploadedBytes': {'type': 'counter'},
+            'secondsActive': {'type': 'gauge'},
+            'sessionCount': {'type': 'gauge'},
+        }
+    }
 
 PLUGIN_NAME = 'transmission'
 
 data = {}
-metrics = {
-    # General metrics
-    'general': {
-        'activeTorrentCount': {'type': 'gauge'},
-        'torrentCount': {'type': 'gauge'},
-        'downloadSpeed': {'type': 'gauge'},
-        'uploadSpeed': {'type': 'gauge'},
-        'pausedTorrentCount': {'type': 'gauge'},
-        'blocklist_size': {'type': 'gauge'},
-    },
-    # All time metrics
-    'cumulative': {
-        'downloadedBytes': {'type': 'counter'},
-        'filesAdded': {'type': 'counter'},
-        'uploadedBytes': {'type': 'counter'},
-        'secondsActive': {'type': 'gauge'},
-        'sessionCount': {'type': 'gauge'},
-    },
-    # Per session (restart) metrics
-    'current': {
-        'downloadedBytes': {'type': 'counter'},
-        'filesAdded': {'type': 'counter'},
-        'uploadedBytes': {'type': 'counter'},
-        'secondsActive': {'type': 'gauge'},
-        'sessionCount': {'type': 'gauge'},
-    }
-}
-
 
 def configuration(config):
     '''
@@ -65,18 +100,18 @@ def initialize():
     username = data['username']
     password = data['password']
     host = data.get('host', 'localhost')
-    port = data.get('port', 9091)
+    port = int(data.get('port', '9091'))
     path = data.get('path', '/transmission/rpc')
     timeout = int(data.get('timeout', '5'))
     try:
-        client = transmission_rpc.Client(
+        client = Client(
             host=host,
             path=path,
             port=port,
             username=username,
             password=password,
             timeout=timeout)
-    except transmission_rpc.error.TransmissionError:
+    except TransmissionError:
         client = None
     data['client'] = client
 
@@ -122,17 +157,18 @@ def get_stats():
     # And let's fetch our data
     try:
         stats = data['client'].session_stats()
-    except transmission_rpc.error.TransmissionError:
+    except TransmissionError:
         shutdown()
         initialize()
         return  # On this run, just fail to return anything
     # Let's get our data
     for category, catmetrics in metrics.items():
         for metric, attrs in catmetrics.items():
+            metric_name = getattr(attrs, 'name', metric)
             values = collectd.Values(
                 type=attrs['type'],
                 plugin=PLUGIN_NAME,
-                type_instance=f'{category}-{metric}')
+                type_instance=f'{category}-{metric_name}')
             values.dispatch(values=[field_getter(stats, metric, category)])
 
 

--- a/tests/test_collectd_transmission.py
+++ b/tests/test_collectd_transmission.py
@@ -45,7 +45,7 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.configuration(self.config)
 
     @mock.patch(
-        'collectd_transmission.transmission_rpc.Client',
+        'collectd_transmission.Client',
         spec=True)
     def test_initialize(self, mock_client):
         '''
@@ -63,7 +63,7 @@ class MethodTestCase(unittest.TestCase):
             timeout=5)
 
     @mock.patch(
-        'collectd_transmission.transmission_rpc.Client',
+        'collectd_transmission.Client',
         spec=True,
         side_effect=TransmissionError)
     def test_initialize_fail(self, mock_client):
@@ -88,7 +88,7 @@ class MethodTestCase(unittest.TestCase):
 
         collectd_transmission.shutdown()
 
-    @mock.patch('collectd_transmission.transmission_rpc.Client', spec=True)
+    @mock.patch('collectd_transmission.Client', spec=True)
     def test_get_stats(self, mock_client):
         '''
         Test getting stats
@@ -98,7 +98,7 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.get_stats()
         mock_client.session_stats.assert_called_with()
 
-    @mock.patch('collectd_transmission.transmission_rpc.Client', spec=True)
+    @mock.patch('collectd_transmission.Client', spec=True)
     def test_get_stats_exception(self, mock_client):
         '''
         Test getting stats with an exception
@@ -110,7 +110,7 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.get_stats()
         mock_client.session_stats.assert_called_with()
 
-    @mock.patch('collectd_transmission.transmission_rpc.Client', spec=True)
+    @mock.patch('collectd_transmission.Client', spec=True)
     def test_get_stats_none_client(self, _):
         '''
         Test getting stats if we don't have a client object


### PR DESCRIPTION
Why:
In transmission-rpc 4.0.0 and later, metric names were altered to be more Pythonic. However, that breaks history for installation of this plugin. We want to see if we can keep them functional

What:
Become more transmission-rpc aware, by import specific objects we use instead of the module. Then based on the successful or failed import of SessionStats, a class introduced in 4.0.0, codify different versions the metric names and use a name key to keep the names constant