### PR TITLE
Add tests against a running transmission daemon

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,10 @@ jobs:
           - "4.0.0"
           - "4.1.5"
           - "4.2.2"
-          - "4.3.0"
+          - "4.3.1"
+          - "5.0.0"
+          - "6.0.0"
+          - "7.0.10"
 
     steps:
     - uses: actions/checkout@v4
@@ -46,6 +49,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: setup transmission
+      run: docker-compose -f utils/docker-compose.yaml up -d
+
     - name: Test with pytest
       run: |
         python -m pip install -e .

--- a/tests/test_collectd_transmission.py
+++ b/tests/test_collectd_transmission.py
@@ -119,6 +119,38 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.data['client'] = None
         collectd_transmission.get_stats()
 
+class LiveTestCase(unittest.TestCase):
+    '''
+    Live testing against a running server
+    '''
+
+    def setUp(self):
+        # Mock our configuration to avoid having to construct them properly
+        self.config = mock.Mock()
+        self.config.children = []
+        child1 = mock.Mock()
+        child1.key = 'username'
+        child1.values = ['myusername']
+        child2 = mock.Mock()
+        child2.key = 'password'
+        child2.values = ['mypassword']
+
+        self.config.children.append(child1)
+        self.config.children.append(child2)
+
+    def tearDown(self):
+        del self.config  # The rest will be handled by GC
+
+    def test_proper_client(self):
+        '''
+        Test using a non mocked Client, talking to a running transmission-daemon
+        on port http://localhost:9091/transmission/rpc, with
+        myusername/mypassword auth creds
+        '''
+
+        collectd_transmission.configuration(self.config)
+        collectd_transmission.initialize()
+        collectd_transmission.get_stats()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_collectd_transmission.py
+++ b/tests/test_collectd_transmission.py
@@ -45,7 +45,7 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.configuration(self.config)
 
     @mock.patch(
-        'collectd_transmission.transmission_rpc.Client',
+        'collectd_transmission.Client',
         spec=True)
     def test_initialize(self, mock_client):
         '''
@@ -63,7 +63,7 @@ class MethodTestCase(unittest.TestCase):
             timeout=5)
 
     @mock.patch(
-        'collectd_transmission.transmission_rpc.Client',
+        'collectd_transmission.Client',
         spec=True,
         side_effect=TransmissionError)
     def test_initialize_fail(self, mock_client):
@@ -88,7 +88,7 @@ class MethodTestCase(unittest.TestCase):
 
         collectd_transmission.shutdown()
 
-    @mock.patch('collectd_transmission.transmission_rpc.Client', spec=True)
+    @mock.patch('collectd_transmission.Client', spec=True)
     def test_get_stats(self, mock_client):
         '''
         Test getting stats
@@ -98,7 +98,7 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.get_stats()
         mock_client.session_stats.assert_called_with()
 
-    @mock.patch('collectd_transmission.transmission_rpc.Client', spec=True)
+    @mock.patch('collectd_transmission.Client', spec=True)
     def test_get_stats_exception(self, mock_client):
         '''
         Test getting stats with an exception
@@ -110,7 +110,7 @@ class MethodTestCase(unittest.TestCase):
         collectd_transmission.get_stats()
         mock_client.session_stats.assert_called_with()
 
-    @mock.patch('collectd_transmission.transmission_rpc.Client', spec=True)
+    @mock.patch('collectd_transmission.Client', spec=True)
     def test_get_stats_none_client(self, _):
         '''
         Test getting stats if we don't have a client object

--- a/utils/docker-compose.yaml
+++ b/utils/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3.3'
+services:
+  transmission:
+    image: caseyfw/transmission
+    container_name: transmission
+    restart: always
+    ports:
+      - 9091:9091
+    environment:
+      UID: '1000'
+      USERNAME: myusername
+      PASSWORD: mypassword


### PR DESCRIPTION
Why:
mock tests can only get us so far. And mocking various versions of transmission_rpc alongside version changes is way too much work

What:
Add an extra step to setup 1 transmission daemon using docker-compose and then create an extra case running a single get_stats instance against it